### PR TITLE
Add bundler install

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -36,6 +36,9 @@ rails_env:                    "development"
 rails_version:                "4.2.4"
 secret_key_base:              "" # will be generated
 
+# bundler
+bundler_version: ">= 2.2.6"
+
 # apache vars
 apache_remove_welcome:        true
 apache_https:                 true

--- a/playbooks/catalyst_install.yml
+++ b/playbooks/catalyst_install.yml
@@ -53,6 +53,11 @@
       exclude: "development, test"
     when: rails_env == 'production'
 
+  - name: install bundler
+    shell:
+      chdir: "{{ deploy_dir }}"
+      cmd: "gem install bundler -v {{ bundler_version }}"
+
   - name: install the project's gems for deployment
     bundler:
       chdir: "{{ deploy_dir }}"


### PR DESCRIPTION
This explicit install is needed when bundlers lock files
are generated with the newer version.