### PR TITLE
Webpack/yarn installation and bundler updates for version 2

### DIFF
--- a/playbooks/catalyst_install.yml
+++ b/playbooks/catalyst_install.yml
@@ -19,7 +19,7 @@
       name: apache
       tasks_from: dolittle
 
-  tasks:
+
   - name: configure application user
     include_tasks: configure_app_user.yml
 
@@ -58,12 +58,22 @@
       chdir: "{{ deploy_dir }}"
       cmd: "gem install bundler -v {{ bundler_version }}"
 
+  - name: set bundle config for local deployment_mode
+    shell:
+      cmd: "bundle config --local deployment true"
+
+  - name: set bundle config to not install dev or test
+    shell:
+      cmd: "bundle config --local without 'development test'"
+
+  - name: set bundle config path
+    shell:
+      cmd: "bundle config --local path '{{deploy_dir}}/vendor/bundle'"
+
   - name: install the project's gems for deployment
-    bundler:
+    shell:
       chdir: "{{ deploy_dir }}"
-      gem_path: "vendor/bundle"
-      deployment_mode: "{{ deployment_mode }}"
-      exclude_groups: "{{ exclude | default(omit) }}"
+      cmd: "bundle install --quiet --jobs 4"
 
   - name: generate rails secret_key_base
     # TODO: use or lose
@@ -100,6 +110,8 @@
       insertafter: "<VirtualHost *:80>"
     notify: restart apache
     become: true
+
+
 
   # NOTE: example
   # - name: override default http logging in virtualhost config
@@ -140,6 +152,16 @@
   #     insertbefore: "</VirtualHost>"
   #   notify: restart apache
   #   become: true
+
+  - name: install yarn
+    shell:
+      cmd: npm install yarn -g
+    become: true
+
+  - name: install yarn packages
+    shell:
+      chdir: "{{ deploy_dir }}"
+      cmd: "yarn install"
 
   # TODO: update to rails command upon updating rails version
   - name: precompile assets


### PR DESCRIPTION
When I ran the the `ruby266` branch on `-test` it was failing because of deprecations related to the bundle install command. This PR changes the way that command is run to get around the deprecations while still behaving in the same way. 

We will also need yarn installed for installing JS dependencies for Rails.