### PR TITLE
Deploy catalyst with Capistrano

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -11,10 +11,10 @@ app_repo:                     "git@github.com:jhu-library-applications/catalyst-
 app_branch:                   "main"
 app_name:                     "catalyst"
 app_user:                     "{{ app_name }}"
-app_group:                    "{{ app_user }}"
+app_group:                    "{{ app_name }}"
 base_deploy_dir:              "/opt"
 deploy_dir:                   "{{ base_deploy_dir }}/{{ app_name }}"
-
+bundle_dir:                   "{{ base_deploy_dir }}/{{ app_name }}/shared/bundle"
 # deploy keys vars
 deploy_user:                  "{{ login_user }}"
 deploy_key_path:              "/home/{{ deploy_user }}/.ssh"
@@ -61,6 +61,8 @@ apache_http_redirect_marker:  "http redirect"
 
 # passenger vars
 # TODO: adopt and move up
+passenger_deploy_dir:         "{{ deploy_dir }}/current/public"
+
 update_packages:        false
 # NOTE: use this to override the passenger virtualhost sub-template
 # passenger_virtualhost_template:     "templates/passenger_virtualhost.j2"

--- a/playbooks/catalyst_install.yml
+++ b/playbooks/catalyst_install.yml
@@ -34,7 +34,7 @@
   - name: get application from repo
     git:
       repo: "{{ app_repo }}"
-      dest: "{{ deploy_dir }}"
+      dest: "{{ ansible_env.HOME }}/{{ app_name }}"
       version: "{{ app_branch | default('HEAD') }}"
       key_file: "{{ catalyst_deploy_key_full_path }}"
       ssh_opts: "-o StrictHostKeyChecking=no"
@@ -55,19 +55,23 @@
 
   - name: install bundler
     shell:
-      chdir: "{{ deploy_dir }}"
+      chdir: "{{ ansible_env.HOME }}/{{ app_name }}"
       cmd: "gem install bundler -v {{ bundler_version }}"
+
+  # This is a global config that will be used
+  # whenever the bundle command is used. This
+  # needs to be set so it will apply when bundle is ran
+  # by capistrano.
+  - name: set bundler shared local path
+    shell:
+      cmd: "bundle config --local path '{{bundle_dir}}'"
 
   - name: install gems with bundler
     bundler:
       state: present
-      gemfile: "{{ deploy_dir }}/Gemfile"
-      exclude_groups:
-        - development
-        - test
+      gemfile: "{{ ansible_env.HOME }}/{{ app_name }}/Gemfile"
       deployment_mode: yes
-      gem_path: "{{deploy_dir}}/vendor/bundle"
-
+      gem_path: "{{ bundle_dir }}"
 
   - name: generate rails secret_key_base
     # TODO: use or lose

--- a/playbooks/templates/catalyst_virtualhost.j2
+++ b/playbooks/templates/catalyst_virtualhost.j2
@@ -23,15 +23,15 @@
   # Cache Rails finger-printed assets, as per
   # http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets
   # Try only match if the asset actually has a fingerprint in it.
-  # <LocationMatch "^/assets/.*-[0-9a-f]{32}.*$">
-  <Location /assets/>
+  <LocationMatch "^/assets/.*-[0-9a-f]{32}.*$">
+  #<Location /assets/>
     # Use of ETag is discouraged when Last-Modified is present
     Header unset ETag
     FileETag None
     # RFC says only cache for 1 year
     ExpiresActive On
     ExpiresDefault "access plus 1 year"
-  </Location>
+  </LocationMatch>
 
   ### TODO: research
   # Let apache serve the pre-compiled .gz version of static assets,


### PR DESCRIPTION
This changes the `catalyst_install` playbook
to use Capistrano for deploying the rails app.

The basic strategy for the deployment is cloning
the git repo to the home folder of the user who
is deploying. The user needs to be in the `catalyst`
group.

In that folder a localhost cap deploy is ran
that deploys to `/opt/catalyst`. That directory needs
read/write permissions for the `catalyst` group.

The apache virtualhost config needs to point to
`/opt/catalyst/current/public`. Capistrano creates the
`current` symlink to point to the latest release. It
keeps 5 releases that can be rolled back to.

This commit also tightens up the install for `yarn` and
`webpack`, which need to be installed before `rails assets:precompile`
is ran as part of the deploy process. Those installs
use conditionals so that they will only be installed if they
are not already present.

This should only be merged when the `capify` branch
for `catalyst-blackight` has been merged.