### PR TITLE
Traject ruby version updates

### DIFF
--- a/inventory/group_vars/all/services.yml
+++ b/inventory/group_vars/all/services.yml
@@ -2,7 +2,5 @@
 # NOTE: anything set here will override environment-specific values
 
 # ruby vars
-service_ruby_version:         "jruby-9.1.16.0"
+service_ruby_version:         "jruby-9.2.13.0"
 service_ruby_path:            "/opt/rubies/{{ service_ruby_version }}"
-
-

--- a/inventory/group_vars/all/services_traject.yml
+++ b/inventory/group_vars/all/services_traject.yml
@@ -2,7 +2,7 @@
 traject_app_user:             "{{ app_user }}"
 traject_app_name:             "catalyst-traject"
 traject_app_repo:             "https://github.com/jhu-sheridan-libraries/catalyst-traject.git"
-traject_app_branch:           "solr-6"
+traject_app_branch:           "master"
 traject_cron_command:         "/bin/bash -lc 'cd {{ service_deploy_dir }} && bundle exec rake horizon:mass_index >> {{ service_log_file }} 2>&1'"
 traject_config_files:
   - template:                 "templates/traject_dotenv.j2"

--- a/playbooks/services_install_traject.yml
+++ b/playbooks/services_install_traject.yml
@@ -7,6 +7,11 @@
 
   tasks:
   - import_role:
+      name: chruby
+    vars:
+      chruby_ruby_version:      "{{ service_ruby_version }}"
+    become: true
+  - import_role:
       name: local.service
     vars:
       service_app_name:         "{{ traject_app_name }}"


### PR DESCRIPTION
This requires https://github.com/jhu-sheridan-libraries/catalyst-traject/tree/bundler-update
to be merged so that it uses the correct version of `bundler`

This installs the newer version of jruby we are using
with traject when running the install_traject playbook.

After running this you should be able to run
```
RAILS_ENV=production bundle exec traject -c conf/horizon_source.rb -c conf/horizon_index.rb -c conf/solr_connect.rb -s horizon.only_bib=7364665
```
without errors.

On `catsolrmaster-test` solr wasn't running. It can be started like this:

`sudo systemctl start solr`