### PR TITLE
Use the bundler module to install gems

### DIFF
--- a/playbooks/catalyst_install.yml
+++ b/playbooks/catalyst_install.yml
@@ -58,22 +58,16 @@
       chdir: "{{ deploy_dir }}"
       cmd: "gem install bundler -v {{ bundler_version }}"
 
-  - name: set bundle config for local deployment_mode
-    shell:
-      cmd: "bundle config --local deployment true"
+  - name: install gems with bundler
+    bundler:
+      state: present
+      gemfile: "{{ deploy_dir }}/Gemfile"
+      exclude_groups:
+        - development
+        - test
+      deployment_mode: yes
+      gem_path: "{{deploy_dir}}/vendor/bundle"
 
-  - name: set bundle config to not install dev or test
-    shell:
-      cmd: "bundle config --local without 'development test'"
-
-  - name: set bundle config path
-    shell:
-      cmd: "bundle config --local path '{{deploy_dir}}/vendor/bundle'"
-
-  - name: install the project's gems for deployment
-    shell:
-      chdir: "{{ deploy_dir }}"
-      cmd: "bundle install --quiet --jobs 4"
 
   - name: generate rails secret_key_base
     # TODO: use or lose


### PR DESCRIPTION
This changes the bundle installation process
to use the ansible module. This raises
deprecation warnings because bundler v2 has
changed the way they are doing configuration.

This should keep working until those deprecations
raise errors or until the ansible module is updated.