### PR TITLE
Mod setup.yml for simplified login-user

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,9 +5,6 @@
 - src: https://github.com/jhu-library-operations/ansible-role-login-user
   name: login-user
 
-- src: https://github.com/jhu-library-applications/ansible-role-secure-ssh
-  name: secure-ssh
-
 - src: https://github.com/jhu-library-applications/ansible-role-deploy-keys
   name: deploy-keys
 

--- a/setup.yml
+++ b/setup.yml
@@ -2,12 +2,8 @@
 - name: create login user for installation & configuration
   hosts: all
 
+  vars:
+    using_vagrant: true
+    
   roles:
   - { role: login-user, tags: ['login-user'] }
-
-- name: secure SSH
-  hosts: all
-  become: true
-
-  roles:
-  - { role: secure-ssh, tags: ['secure-ssh'] }


### PR DESCRIPTION
I'd like to propose modifying `setup.yml` (called by the vagrant provision step) to work with the simplified version of `ansible-role-login-user` (currently under `jhu-libraries-operations`).
1. The new `ansible-role-login-user` has only been tested for vagrant -- I'll work on that. But for now, explicitly setting `using_vagrant` to true clarifies that.
2. The `jhu-library-applications/ansible-role-secure-ssh` role is not helpful and should be eliminated entirely in my opinion. Restricting SSH to root only is on OPS. 

Thanks!