### PR TITLE
Swap out logrotate ansible role

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -110,19 +110,44 @@ bantheman_configs:
       # - "^/catalog/bib_.*$"
       # - "^/catalog\\?.*$"
 
-logrotate_configs:
-  - name: "catalyst"
-    path: "{{ deploy_dir }}/log"
-    setype: "var_log_t"
-    options:
-      - "su catalyst catalyst"
-      - "daily"
-      - "rotate 24"
-      - "compress"
-      - "delaycompress"
-      - "missingok"
-      - "create 0600"
-      - "dateext"
+# Logrotate for wtmp
+logrotate_wtmp_enable: true
+logrotate_wtmp:
+  logs:
+    - /var/log/wtmp
+  options:
+    - monthly
+    - create 0664 root utmp
+    - "    minsize 1M"
+    - rotate 1
+
+logrotate_applications:
+  - name: catalyst
+    definitions:
+      - logs:
+        - "{{ deploy_dir }}/log/*log"
+        options:
+          - su catalyst catalyst
+          - daily
+          - rotate 24
+          - compress
+          - delaycompress
+          - missingok
+          - create 0600
+          - dateext
+  - name: httpd
+    definitions:
+      - logs:
+        - "/var/log/httpd/*log"
+        options:
+          - missingok
+          - notifempty
+          - sharedscripts
+          - compress
+          - delaycompress
+          - postrotate
+          - "    /bin/systemctl reload httpd.service > /dev/null 2>/dev/null || true"
+          - endscript
 
 testup_cucumber_vars_template:  "templates/test_vars.rb"
 testup_relative_path_to_root:   "../"

--- a/requirements.yml
+++ b/requirements.yml
@@ -35,7 +35,7 @@
 - src: https://github.com/jhu-library-applications/ansible-role-bantheman
   name: bantheman
 
-- src: https://github.com/jhu-library-applications/ansible-role-logrotate
+- src: https://github.com/arillso/ansible.logrotate.git
   name: logrotate
 
 - src: https://github.com/jhu-library-applications/ansible-role-testup


### PR DESCRIPTION
This PR is to propose swapping out our custom ansible role for `logrotate` with one from Arillso that will be hopefully more standardized and that we don't need to maintain.