### PR TITLE
Use systemd to manage solr service

### DIFF
--- a/playbooks/solr_service.yml
+++ b/playbooks/solr_service.yml
@@ -1,0 +1,44 @@
+---
+- name: install solr as a systemd service
+  hosts: solr
+  tags:
+    - solr
+
+  tasks:
+    - name: Stop solr server
+      ansible.builtin.service:
+        name: solr
+        state: stopped
+        Enabled: no
+      become: yes
+
+    - name: Remove solr init.d file
+      file:
+        path: /etc/init.d/solr
+        state: absent
+      become: yes
+
+    - name: Copy solr service
+      template:
+        src: "solr_service.j2"
+        dest: "/lib/systemd/system/solr.service"
+        owner: root
+        mode: 0755
+      become: yes
+
+    - name: Enable solr service
+      systemd:
+        name: "solr"
+        enabled: yes
+        masked: no
+        daemon_reload: yes
+        state: restarted
+      become: yes
+
+    - name: make sure daemon is reloaded (ansible bug)
+      shell: systemctl daemon-reload
+      become: yes
+
+    - name: Restart Solr
+      service: name=solr state=restarted enabled=yes
+      become: yes

--- a/playbooks/templates/solr_service.j2
+++ b/playbooks/templates/solr_service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apache SOLR
+
+[Service]
+Type=forking
+User=solr
+Environment=SOLR_INCLUDE=/etc/default/solr.in.sh
+ExecStart=/opt/solr/bin/solr start
+ExecStop=/opt/solr/bin/solr stop
+Restart=on-failure
+LimitNOFILE=65000
+LimitNPROC=65000
+TimeoutSec=180s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This changes the way the solr service is managed
on the VM so that it uses `systemd`.

This way we can have the service automatically
restart if it goes down. Over the past few weeks
we have had the `oom_memory_killer` script for
solr run and then solr isn't restarted.