### PR TITLE
Updated java role to use Jeff Geerling's.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -8,7 +8,7 @@
 - src: https://github.com/jhu-library-applications/ansible-role-deploy-keys
   name: deploy-keys
 
-- src: https://github.com/jhu-library-applications/ansible-role-java
+- src: https://github.com/geerlingguy/ansible-role-java
   name: java
 
 - src: https://github.com/jhu-library-devops/ansible-role-ssl-certs.git


### PR DESCRIPTION
Hi John/Jamie,

I'm opening this pull request to swap out our local `ansible-role-java` with Jeff Geerling's role for installing Java. As with other cases, the thinking is to re-use a role that is maintained while not having to maintain it ourselves.

Thanks,
Jeff