### PR TITLE
Added empty appsignal_push_api_key variable to dev/vars.yml

### DIFF
--- a/inventory/group_vars/dev/vars.yml
+++ b/inventory/group_vars/dev/vars.yml
@@ -62,6 +62,11 @@ sentry_env:             "test"
 # Google API for retrieving book covers
 google_books_api_key:   "{{ vault_google_books_api_key }}"
 
+
+# AppSignal
+
+appsignal_push_api_key: ""
+
 # catalyst/findit vars.
 # catalyst_base_url is a callback used by findit. It has to be a server that findit can access
 catalyst_base_url:      "https://catalyst-stage.library.jhu.edu"


### PR DESCRIPTION
I added an empty `appsignal_push_api_key` variable to inventory/group_vars/dev/vars.yml in order to get catalyst-ansible to deploy on the vagrant environment.